### PR TITLE
Make runjobflowrequest synchronous

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -111,6 +111,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.12.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
             <version>1.3.0</version>
@@ -130,6 +136,12 @@
                     <artifactId>aws-java-sdk-logs</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>DataMigrationTool</groupId>
+            <artifactId>DataMigrationFramework</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/api/src/main/java/com/homeaway/datapullclient/config/DataPullClientConfig.java
+++ b/api/src/main/java/com/homeaway/datapullclient/config/DataPullClientConfig.java
@@ -52,8 +52,8 @@ public class DataPullClientConfig {
 
     @Bean
     @Scope("prototype")
-    public DataPullTask getTask(String taskId, String json, String jksFile, List<String> subnets, Map<String, List<DescribeStepRequest>> stepPipelineMap) {
-        return new DataPullTask(taskId, json, jksFile, subnets, stepPipelineMap);
+    public DataPullTask getTask(String taskId, String creator, String json, String jksFile, List<String> subnets, Map<String, List<DescribeStepRequest>> stepPipelineMap) {
+        return new DataPullTask(taskId, creator, json, jksFile, subnets, stepPipelineMap);
     }
 
     @Bean

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
@@ -351,7 +351,7 @@ public class DataPullRequestProcessor implements DataPullClientService {
 
     private DataPullTask createDataPullTask(String fileS3Path, String jksFilePath, ClusterProperties properties, String jobName, String creator, String customJarFilePath,  Boolean haveBootstrapAction) {
         String creatorTag = String.join(" ", Arrays.asList(creator.split(",|;")));
-        DataPullTask task = config.getTask(jobName, fileS3Path, jksFilePath,rotateSubnets(),getStepForPipeline()).withClusterProperties(properties).withCustomJar(customJarFilePath).haveBootstrapAction(haveBootstrapAction)
+        DataPullTask task = config.getTask(jobName, creator, fileS3Path, jksFilePath,rotateSubnets(),getStepForPipeline()).withClusterProperties(properties).withCustomJar(customJarFilePath).haveBootstrapAction(haveBootstrapAction)
                 .addTag("Creator", creatorTag).addTag("Env", Objects.toString(properties.getAwsEnv(), env)).addTag("Name", jobName)
                 .addTag("AssetProtectionLevel", "99").addTag("ComponentInfo", properties.getComponentInfo())
                 .addTag("Portfolio", properties.getPortfolio()).addTag("Product", properties.getProduct()).addTag("Team", properties.getTeam()).addTag("tool", "datapull")


### PR DESCRIPTION
# DataPull PR

* Made the runJobFlowRequest to be synchronous.
* Added email notification in case of cluster termination.

### Changed
* api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
* api/pom.xml
* api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
* api/src/main/java/com/homeaway/datapullclient/config/DataPullClientConfig.java


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
