### PR TITLE
Fix null/invalid default subnet selection for EMR

### DIFF
--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
@@ -74,6 +74,7 @@ public class DataPullRequestProcessor implements DataPullClientService {
     private static final String PIPELINE_NAME_DELIMITER = "-";
     private static final int POOL_SIZE = 10;
     private static final String EMR = "emr";
+    private static final String SUBNET_ID_PREFIX = "subnet-";
     private static final String CREATOR = "useremailaddress";
     private Schema inputJsonSchema;
     @Autowired
@@ -258,17 +259,20 @@ public class DataPullRequestProcessor implements DataPullClientService {
             log.debug("runDataPull <- return");
     }
 
-    List<String> rotateSubnets(){
+    synchronized List<String> rotateSubnets(){
 
         if(subnets.isEmpty()){
             subnets= getSubnet();
+            if (subnets.isEmpty()) {
+                log.warn("No valid default subnet IDs are configured for datapull.api.application_subnet_[1-3].");
+            }
         }else{
             List<String> subnetIds_shuffled = new ArrayList<>(subnets);
             Collections.rotate(subnetIds_shuffled, 1);
             subnets.clear();
             subnets.addAll(subnetIds_shuffled);
         }
-        return subnets;
+        return new ArrayList<>(subnets);
     }
 
    Map<String,List<DescribeStepRequest>> getStepForPipeline(){
@@ -277,18 +281,16 @@ public class DataPullRequestProcessor implements DataPullClientService {
     public List<String> getSubnet(){
         final DataPullProperties dataPullProperties = this.config.getDataPullProperties();
 
-        List<String> subnetIds = new ArrayList<>();
-
-        subnetIds.add(dataPullProperties.getApplicationSubnet1());
-
-        if (StringUtils.isNotBlank(dataPullProperties.getApplicationSubnet2())) {
-            subnetIds.add(dataPullProperties.getApplicationSubnet2());
-        }
-
-        if (StringUtils.isNotBlank(dataPullProperties.getApplicationSubnet3())) {
-            subnetIds.add(dataPullProperties.getApplicationSubnet3());
-        }
-        return  subnetIds;
+        return Arrays.asList(
+                        dataPullProperties.getApplicationSubnet1(),
+                        dataPullProperties.getApplicationSubnet2(),
+                        dataPullProperties.getApplicationSubnet3())
+                .stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .filter(subnetId -> subnetId.startsWith(SUBNET_ID_PREFIX))
+                .distinct()
+                .collect(Collectors.toList());
 
     }
     private StringBuilder createBootstrapString(Object[] paths, String bootstrapActionStringFromUser) throws ProcessingException {

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -519,14 +519,6 @@ public class DataPullTask implements Runnable {
         final String serviceAccessSecurityGroup = Objects.toString(
                 this.clusterProperties.getServiceAccessSecurityGroup(), serviceAccesss != null ? serviceAccesss : "");
 
-        List<String> defaultSubnets = subnets.stream()
-                .filter(StringUtils::isNotBlank)
-                .map(String::trim)
-                .filter(subnetId -> subnetId.startsWith("subnet-"))
-                .distinct()
-                .collect(Collectors.toList());
-        System.out.println("Printing random subnet : " + defaultSubnets);
-
 //      Introducing below logic to address null and invalid subnet issue
         String getSubnetId = StringUtils.trimToNull(clusterProperties.getSubnetId());
         String finalSubnetId;
@@ -542,10 +534,7 @@ public class DataPullTask implements Runnable {
                 System.out.println("The user either provided a NULL value for the subnet or did not specify subnet in the payload. Hence, the default subnet pool will be used for EMR creation.");
             }
 
-            if (defaultSubnets.isEmpty()) {
-                throw new IllegalStateException("No valid default subnet is configured for datapull.api.application_subnet_[1-3].");
-            }
-            finalSubnetId = defaultSubnets.get(0);
+            finalSubnetId = getNextDefaultSubnet();
             System.out.println("EMR cluster will be created using a subnet from the default subnet pool: " + finalSubnetId);
         }
         System.out.println("Printing selected subnet-ID for EMR cluster creation : " + finalSubnetId);
@@ -574,6 +563,29 @@ public class DataPullTask implements Runnable {
             jobConfig.withInstanceFleets(workerInstanceFleetConfig);
         }
         return jobConfig;
+    }
+
+    private String getNextDefaultSubnet() {
+        synchronized (subnets) {
+            List<String> defaultSubnets = subnets.stream()
+                    .filter(StringUtils::isNotBlank)
+                    .map(String::trim)
+                    .filter(subnetId -> subnetId.startsWith("subnet-"))
+                    .distinct()
+                    .collect(Collectors.toList());
+
+            System.out.println("Printing random subnet : " + defaultSubnets);
+
+            if (defaultSubnets.isEmpty()) {
+                throw new IllegalStateException("No valid default subnet is configured for datapull.api.application_subnet_[1-3].");
+            }
+
+            String selectedSubnet = defaultSubnets.get(0);
+            Collections.rotate(defaultSubnets, 1);
+            subnets.clear();
+            subnets.addAll(defaultSubnets);
+            return selectedSubnet;
+        }
     }
 
     private void addTagsToEMRCluster() {

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -509,10 +509,6 @@ public class DataPullTask implements Runnable {
                 .withInstanceTypeConfigs(workerInstanceTypeConfig)
                 .withTargetOnDemandCapacity(count);
 
-        System.out.println("Printing random subnet : " + subnets);
-
-        System.out.println("Printing selected subnet-ID for EMR cluster creation : " +  subnets.get(0));
-
         final String masterSG = emrProperties.getEmrSecurityGroupMaster();
         final String slaveSG = emrProperties.getEmrSecurityGroupSlave();
         final String serviceAccesss = emrProperties.getEmrSecurityGroupServiceAccess();
@@ -523,12 +519,16 @@ public class DataPullTask implements Runnable {
         final String serviceAccessSecurityGroup = Objects.toString(
                 this.clusterProperties.getServiceAccessSecurityGroup(), serviceAccesss != null ? serviceAccesss : "");
 
-        if(StringUtils.isNotBlank(clusterProperties.getSubnetId())){
-            subnets.add(0,clusterProperties.getSubnetId());
-        }
+        List<String> defaultSubnets = subnets.stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .filter(subnetId -> subnetId.startsWith("subnet-"))
+                .distinct()
+                .collect(Collectors.toList());
+        System.out.println("Printing random subnet : " + defaultSubnets);
 
 //      Introducing below logic to address null and invalid subnet issue
-        String getSubnetId = clusterProperties.getSubnetId();
+        String getSubnetId = StringUtils.trimToNull(clusterProperties.getSubnetId());
         String finalSubnetId;
 
 
@@ -542,13 +542,13 @@ public class DataPullTask implements Runnable {
                 System.out.println("The user either provided a NULL value for the subnet or did not specify subnet in the payload. Hence, the default subnet pool will be used for EMR creation.");
             }
 
-            Set<String> subnetsDeduped = new LinkedHashSet<>(subnets);
-            subnets.clear();
-            subnets.addAll(subnetsDeduped);
-
-            finalSubnetId = subnets.get(0);
+            if (defaultSubnets.isEmpty()) {
+                throw new IllegalStateException("No valid default subnet is configured for datapull.api.application_subnet_[1-3].");
+            }
+            finalSubnetId = defaultSubnets.get(0);
             System.out.println("EMR cluster will be created using a subnet from the default subnet pool: " + finalSubnetId);
         }
+        System.out.println("Printing selected subnet-ID for EMR cluster creation : " + finalSubnetId);
 
         final JobFlowInstancesConfig jobConfig = new JobFlowInstancesConfig()
                 .withEc2SubnetIds(finalSubnetId)


### PR DESCRIPTION
# DataPull PR

## Why

Datapull intermittently failed EMR cluster creation with:

`AmazonElasticMapReduceException: A null value was specified in subnetIds`

This was intermittent because default subnets are rotated; when a null/default-invalid entry rotated to index 0, EMR got `null` for subnet ID.

## What changed

1. Hardened default subnet pool construction
- File: api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
- `getSubnet()` now:
  - reads `application_subnet_1/2/3`
  - filters null/blank values
  - trims values
  - keeps only values that start with `subnet-`
  - de-duplicates
- `rotateSubnets()` now:
  - is `synchronized`
  - returns a defensive copy (`new ArrayList<>(subnets)`)
  - logs warning when no valid defaults are configured

2. Removed shared-list mutation during runtime subnet selection
- File: api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
- `getJobFlowInstancesConfig()` now:
  - builds a sanitized local `defaultSubnets` list from provided defaults
  - does not mutate shared `subnets` list
  - uses payload subnet only if valid (`subnet-*`)
  - falls back to first valid default subnet
  - throws clear error if no valid default subnet exists:
    `No valid default subnet is configured for datapull.api.application_subnet_[1-3].`

3. Logging now prints the actually selected final subnet ID
- avoids misleading logs from pre-selection list state

## Impact

- Prevents null from being passed to EMR `subnetIds`
- Eliminates intermittent null-subnet behavior caused by subnet rotation
- Converts misconfiguration into deterministic, actionable error